### PR TITLE
feat: add functionality for specifying the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ module.exports = {
     options: {
       apiKey: 'YOUR_API_KEY',
       revision: `${Date.now()}`,
-      assetsUrl: 'https://foobar.com/assets'
+      assetsUrl: 'https://foobar.com/assets',
+      environment: process.env.NODE_ENV
     }
   ]
 }
@@ -29,3 +30,4 @@ module.exports = {
 - `[apiKey]` _(String)_: the API key of your Honeybadger project.
 - `[revision]` _(String)_: `gatsby-plugin-honeybadger` uses [`honeybadger-webpack`](https://github.com/honeybadger-io/honeybadger-webpack) to upload source maps to Honeybadger. `options.revision` needs to be unique as it is the identifier that connects your errors to your source maps.
 - `[assetsURL]` _(String)_: The base URL to production assets (scheme://host/path). Used to grab source maps.
+- `[environment]` _(String)_: Current environment. Used to indicate the environment where the error occurred. **Optional**, defaults to `process.env.NODE_ENV`.

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,6 @@
 const Honeybadger = require('honeybadger-js')
 
-exports.onClientEntry = function(_, { apiKey, revision }) {
+exports.onClientEntry = function(_, { apiKey, revision, environment = process.env.NODE_ENV }) {
   if (!apiKey) {
     console.warn('gatsby-plugin-honeybadger needs an API key to be configured properly {url for documentation}')
     return
@@ -9,6 +9,6 @@ exports.onClientEntry = function(_, { apiKey, revision }) {
   Honeybadger.configure({
     apiKey,
     revision,
-    environment: process.env.NODE_ENV
+    environment
   })
 }


### PR DESCRIPTION
The current functionality of the plugin does not allow you to set the value of the current environment, it's `process.env.NODE_ENV` by default and can't be changed by the user . At the same time, the application settings may specify an environment that is different from the value of `process.env.NODE_ENV`. The user should be able to set his own value for the current environment if needed.

Changes introduced in this PR will allow the user to set his own value for the current environment. If `environment` isn't specified in plugin's options it defaults to `process.env.NODE_ENV` so these changes won't break anything.